### PR TITLE
chore: release version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-01-07
+
+### Changed
+- Updated all repository URLs from placeholder to TJC-LP organization
+- Added disclaimer clarifying unofficial MCP server status and TJC L.P. development
+
+### Documentation
+- Updated pyproject.toml with correct GitHub URLs
+- Updated CONTRIBUTING.md with correct repository links
+- Updated README.md with disclaimer note
+- Updated CHANGELOG.md with correct version links
+
+## [0.1.0] - 2025-01-06
+
+Initial release.
+
 ### Added
-- Initial release of Coda MCP Server
 - Support for listing Coda documents
 - Support for creating new Coda pages
 - Support for reading Coda page content
@@ -28,9 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API tokens are handled securely via environment variables
 - No sensitive information is logged
 
-## [0.1.0] - TBD
-
-Initial release.
-
-[Unreleased]: https://github.com/TJC-LP/coda-mcp-server/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/TJC-LP/coda-mcp-server/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/TJC-LP/coda-mcp-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/TJC-LP/coda-mcp-server/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coda-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "An MCP server which integrates with Coda.io"
 authors = [
     { name = "Richie Caputo", email = "rcaputo3@tjclp.com" }


### PR DESCRIPTION
## Summary
Prepare for release 0.1.1 with documentation improvements and repository URL updates.

## Changes
- Bump version from 0.1.0 to 0.1.1 in pyproject.toml
- Updated CHANGELOG.md with release notes for 0.1.1
- All repository URLs updated to TJC-LP organization
- Added disclaimer about unofficial MCP status

## Release Notes
### Changed
- Updated all repository URLs from placeholder to TJC-LP organization
- Added disclaimer clarifying unofficial MCP server status and TJC L.P. development

### Documentation
- Updated pyproject.toml with correct GitHub URLs
- Updated CONTRIBUTING.md with correct repository links
- Updated README.md with disclaimer note
- Updated CHANGELOG.md with correct version links

## Test plan
- [ ] Verify version number is correct (0.1.1)
- [ ] Review changelog entries
- [ ] Confirm all URLs point to TJC-LP organization
- [ ] After merge, tag with v0.1.1 to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)