### PR TITLE
feat: add surgical page content element tools

### DIFF
--- a/src/coda_mcp_server/models/__init__.py
+++ b/src/coda_mcp_server/models/__init__.py
@@ -72,9 +72,13 @@ from .formulas import (
 # Import page-related models
 from .pages import (
     CanvasPageContent,
+    DeletePageContentRequest,
+    DeletePageContentResult,
     EmbedPageContent,
     Page,
     PageContent,
+    PageContentElement,
+    PageContentElementList,
     PageContentUpdate,
     PageCreate,
     PageCreateResult,
@@ -261,6 +265,11 @@ __all__ = [
     "PageCreateResult",
     "PageUpdateResult",
     "PageDeleteResult",
+    # Page Content Elements (for surgical updates)
+    "PageContentElement",
+    "PageContentElementList",
+    "DeletePageContentRequest",
+    "DeletePageContentResult",
     # Exports
     "BeginPageContentExportRequest",
     "BeginPageContentExportResponse",

--- a/src/coda_mcp_server/models/pages.py
+++ b/src/coda_mcp_server/models/pages.py
@@ -128,6 +128,15 @@ class PageContentUpdate(CodaBaseModel):
 
     insertion_mode: Literal["append", "replace"] = Field(..., description="Mode for inserting content.")
     canvas_content: PageContent = Field(..., description="The canvas content to insert.")
+    element_id: str | None = Field(
+        None,
+        description=(
+            "Element ID to target for insertion. When provided with insertion_mode='append', "
+            "content will be inserted after this element. Get element IDs from list_page_content_elements. "
+            "This enables surgical updates without overwriting the entire page."
+        ),
+        examples=["cl-L80qn4IXoO"],
+    )
 
 
 class PageUpdate(CodaBaseModel):
@@ -173,3 +182,44 @@ class PageDeleteResult(DocumentMutateResponse):
     """The result of a page deletion."""
 
     id: str = Field(..., description="ID of the page to be deleted.", examples=["canvas-tuVwxYz"])
+
+
+# ============================================================================
+# Page Content Element Models (for surgical updates)
+# ============================================================================
+
+
+class PageContentElement(CodaBaseModel):
+    """An individual content element on a page.
+
+    Elements have IDs prefixed with 'cl-' (e.g., 'cl-L80qn4IXoO').
+    These IDs can be used with delete_page_content_elements or
+    as element_id in PageContentUpdate for surgical page updates.
+    """
+
+    id: str = Field(..., description="Element ID (prefixed with 'cl-').", examples=["cl-L80qn4IXoO"])
+    type: str = Field(..., description="Type of element (e.g., 'text', 'heading', 'grid').")
+    content: str | None = Field(None, description="Text content of the element, if applicable.")
+
+
+class PageContentElementList(CodaBaseModel):
+    """List of content elements on a page."""
+
+    items: list[PageContentElement] = Field(..., description="List of content elements.")
+    href: str | None = Field(None, description="API link to these results.")
+
+
+class DeletePageContentRequest(CodaBaseModel):
+    """Request payload for deleting specific content elements from a page."""
+
+    element_ids: list[str] = Field(
+        ...,
+        description="List of element IDs to delete (prefixed with 'cl-').",
+        examples=[["cl-L80qn4IXoO", "cl-M91rp5JYpP"]],
+    )
+
+
+class DeletePageContentResult(CodaBaseModel):
+    """Result of deleting content elements from a page."""
+
+    deleted_element_ids: list[str] = Field(..., description="IDs of successfully deleted elements.")

--- a/src/coda_mcp_server/server.py
+++ b/src/coda_mcp_server/server.py
@@ -11,6 +11,8 @@ from .models import (
     CanvasPageContent,
     Column,
     ColumnList,
+    DeletePageContentRequest,
+    DeletePageContentResult,
     Doc,
     DocCreate,
     DocDelete,
@@ -22,6 +24,8 @@ from .models import (
     Formula,
     FormulaList,
     Page,
+    PageContentElement,
+    PageContentElementList,
     PageContentExportStatusResponse,
     PageContentUpdate,
     PageCreate,
@@ -375,6 +379,66 @@ async def create_page(
         page_content=page_content,
     )
     return await pages.create_page(client, doc_id, page_create)
+
+
+@mcp.tool(
+    description=(
+        "List all content elements on a page with their element IDs - "
+        "use this to get element IDs for surgical page updates or deletions"
+    )
+)
+async def list_page_content_elements(
+    doc_id: str,
+    page_id_or_name: str,
+) -> PageContentElementList:
+    """List all content elements on a page.
+
+    This returns individual content elements (headings, paragraphs, tables, etc.)
+    with their element IDs. These IDs can be used for:
+    - Deleting specific elements with delete_page_content_elements
+    - Inserting content after a specific element using element_id in update_page
+
+    Element IDs are prefixed with 'cl-' (e.g., 'cl-L80qn4IXoO').
+
+    Args:
+        doc_id: ID of the doc.
+        page_id_or_name: ID or name of the page.
+
+    Returns:
+        List of content elements with their IDs and types.
+    """
+    return await pages.list_page_content_elements(client, doc_id, page_id_or_name)
+
+
+@mcp.tool(
+    description=(
+        "Delete specific content elements from a page by their element IDs - "
+        "enables surgical removal without affecting other content like embedded tables/views"
+    )
+)
+async def delete_page_content_elements(
+    doc_id: str,
+    page_id_or_name: str,
+    element_ids: list[str],
+) -> DeletePageContentResult:
+    """Delete specific content elements from a page.
+
+    This enables surgical removal of individual elements (headings, paragraphs, etc.)
+    without affecting other page content like embedded tables/views.
+
+    Get element IDs using list_page_content_elements first.
+    Element IDs are prefixed with 'cl-' (e.g., 'cl-L80qn4IXoO').
+
+    Args:
+        doc_id: ID of the doc.
+        page_id_or_name: ID or name of the page.
+        element_ids: List of element IDs to delete.
+
+    Returns:
+        Result with the deleted element IDs.
+    """
+    delete_request = DeletePageContentRequest(element_ids=element_ids)
+    return await pages.delete_page_content_elements(client, doc_id, page_id_or_name, delete_request)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Add `list_page_content_elements` tool to get element IDs for surgical page updates
- Add `delete_page_content_elements` tool to delete specific elements by ID
- Add `element_id` parameter to `PageContentUpdate` for inserting content after a specific element

## Problem
When using `update_page` with `insertion_mode: "replace"`, embedded Coda tables and views are destroyed. This makes it impossible to update page text while preserving structured data.

## Solution
These tools enable surgical updates by:
1. Listing all content elements with their IDs
2. Inserting new content after a specific element (using `element_id` with `insertion_mode: "append"`)
3. Deleting specific elements without affecting others

## Use Case
Updating municipality client pages that contain both markdown content and embedded contact info tables. The new tools allow updating the markdown sections while preserving the embedded tables.

## Files Changed
- `models/__init__.py` - Export new models
- `models/pages.py` - Add `PageContentElement` and `PageContentElementList` models
- `server.py` - Register new tools
- `tools/pages.py` - Implement `list_page_content_elements` and `delete_page_content_elements`

## Testing
Tested against live Coda documents with embedded tables. Successfully:
- Listed elements and mapped them to page content
- Inserted content after specific headers
- Deleted placeholder text elements without affecting embedded tables